### PR TITLE
Base Entity final 키워드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ bin/
 
 ### config ###
 /src/main/resources/env.properties
+/src/main/resources/queries.xml

--- a/src/main/java/com/lxp/base/BaseDateCreatedEntity.java
+++ b/src/main/java/com/lxp/base/BaseDateCreatedEntity.java
@@ -3,9 +3,10 @@ package com.lxp.base;
 import java.time.LocalDateTime;
 
 public abstract class BaseDateCreatedEntity extends BaseEntity {
-    private LocalDateTime dateCreated;
+    private final LocalDateTime dateCreated;
 
-    public void recordCreationTime() {
+    protected BaseDateCreatedEntity(Long id) {
+        super(id);
         this.dateCreated = LocalDateTime.now();
     }
 

--- a/src/main/java/com/lxp/base/BaseDateModifiedEntity.java
+++ b/src/main/java/com/lxp/base/BaseDateModifiedEntity.java
@@ -5,6 +5,11 @@ import java.time.LocalDateTime;
 public abstract class BaseDateModifiedEntity extends BaseDateCreatedEntity {
     private LocalDateTime dateModified;
 
+    protected BaseDateModifiedEntity(Long id) {
+        super(id);
+        this.dateModified = this.getDateCreated();
+    }
+    
     public void recordDateModified() {
         this.dateModified = LocalDateTime.now();
     }

--- a/src/main/java/com/lxp/base/BaseEntity.java
+++ b/src/main/java/com/lxp/base/BaseEntity.java
@@ -1,7 +1,11 @@
 package com.lxp.base;
 
 public abstract class BaseEntity {
-    private Long id;
+    private final Long id;
+
+    protected BaseEntity(Long id) {
+        this.id = id;
+    }
 
     public Long getId() {
         return id;


### PR DESCRIPTION
## 변경 사항
- 한 번 생성된 객체의 id 값은 불변해야 한다고 생각하여 `final` 키워드를 추가하였습니다.
- `BaseEntity`를 상속하는 이외의 클래스에서 `dateCreated`도 생성 시점 이후 변경될 일이 없습니다.
- `dateModified`는 추후 수정 가능성이 있어서 `final` 키워드를 제외하고 생성 시점에는 `dateCreated`의 값으로 초기화를 한 후 갱신하는 방법으로 구현했습니다.