### PR TITLE
Base Entity final 키워드 제거

### DIFF
--- a/src/main/java/com/lxp/base/BaseDateCreatedEntity.java
+++ b/src/main/java/com/lxp/base/BaseDateCreatedEntity.java
@@ -3,10 +3,9 @@ package com.lxp.base;
 import java.time.LocalDateTime;
 
 public abstract class BaseDateCreatedEntity extends BaseEntity {
-    private final LocalDateTime dateCreated;
+    private LocalDateTime dateCreated;
 
-    protected BaseDateCreatedEntity(Long id) {
-        super(id);
+    public void recordCreationTime() {
         this.dateCreated = LocalDateTime.now();
     }
 

--- a/src/main/java/com/lxp/base/BaseDateModifiedEntity.java
+++ b/src/main/java/com/lxp/base/BaseDateModifiedEntity.java
@@ -5,11 +5,6 @@ import java.time.LocalDateTime;
 public abstract class BaseDateModifiedEntity extends BaseDateCreatedEntity {
     private LocalDateTime dateModified;
 
-    protected BaseDateModifiedEntity(Long id) {
-        super(id);
-        this.dateModified = this.getDateCreated();
-    }
-    
     public void recordDateModified() {
         this.dateModified = LocalDateTime.now();
     }

--- a/src/main/java/com/lxp/base/BaseEntity.java
+++ b/src/main/java/com/lxp/base/BaseEntity.java
@@ -1,11 +1,7 @@
 package com.lxp.base;
 
 public abstract class BaseEntity {
-    private final Long id;
-
-    protected BaseEntity(Long id) {
-        this.id = id;
-    }
+    private Long id;
 
     public Long getId() {
         return id;

--- a/src/main/java/com/lxp/config/DBConfig.java
+++ b/src/main/java/com/lxp/config/DBConfig.java
@@ -10,14 +10,22 @@ import java.util.Properties;
 
 public class DBConfig implements AutoCloseable {
 
+    private static DBConfig instance;
     private final HikariDataSource dataSource;
 
-    public DBConfig() {
+    private DBConfig() {
         this.dataSource = getDataSource(new Properties());
 
         if (dataSource == null) {
             throw new NullPointerException("dataSource is null");
         }
+    }
+
+    public static synchronized DBConfig getInstance() {
+        if (instance == null) {
+            instance = new DBConfig();
+        }
+        return instance;
     }
 
     public Connection getConnection() throws SQLException {

--- a/src/main/java/com/lxp/support/QueryUtil.java
+++ b/src/main/java/com/lxp/support/QueryUtil.java
@@ -1,6 +1,5 @@
 package com.lxp.support;
 
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;


### PR DESCRIPTION
## 변경 사유
- DB에서 데이터를 읽어올 때 빈 객체를 생성한 후 필드 값을 채워 넣어야 하므로, 생성 시에만 초기화가 가능한 final 키워드를 제거하여 데이터 매핑의 유연성을 확보합니다.